### PR TITLE
Iban string fix

### DIFF
--- a/iban-validator/src/main/java/com/intive/iban/validator/IbanValidator.java
+++ b/iban-validator/src/main/java/com/intive/iban/validator/IbanValidator.java
@@ -17,7 +17,7 @@ public class IbanValidator implements ConstraintValidator<IbanFormat, String> {
 
     public boolean isValid(String iban, ConstraintValidatorContext context) {
         try {
-            IbanUtil.validate(COUNTRY_CODE + iban);
+            IbanUtil.validate(String.format("%s%s", COUNTRY_CODE, iban));
             return true;
         } catch (IbanFormatException | InvalidCheckDigitException | UnsupportedCountryException e) {
             setErrorMessage(context, e.getMessage());

--- a/iban-validator/src/test/java/com/intive/iban/validator/IbanValidatorTest.java
+++ b/iban-validator/src/test/java/com/intive/iban/validator/IbanValidatorTest.java
@@ -27,17 +27,18 @@ public class IbanValidatorTest {
         this.validator = factory.getValidator();
     }
 
-    @DataProvider
+    @DataProvider(trimValues = false)
     public static String[] dataProviderValidIban() {
         return new String[]{
                 "60102010260000042270201111",
-                " 61109010140000071219812874",
-                "27114020040000300201355387 "};
+                "27114020040000300201355387"};
     }
 
-    @DataProvider
+    @DataProvider(trimValues = false)
     public static String[] dataProviderInvalidIban() {
         return new String[]{
+                " 61109010140000071219812874",
+                "27114020040000300201355387 ",
                 "601020102600000422=70201111",
                 "2 7114020040000300201355387",
                 "\"61109010140000071219811\\\\n\"",


### PR DESCRIPTION
Turns out iban4j actually checks if there are spaces at the start and/or at the end of the iban string, and marks them invalid. The bug was in the tests, where the strings returned from DataProvider were automatically trimmed by DataProvider.