### PR TITLE
Do not change pets and news image on update

### DIFF
--- a/src/main/java/com/intive/patronage/toz/news/NewsService.java
+++ b/src/main/java/com/intive/patronage/toz/news/NewsService.java
@@ -66,7 +66,10 @@ class NewsService {
 
     News updateNews(final UUID id, final News news) {
         RepositoryChecker.throwNotFoundExceptionIfNotExists(id, newsRepository, NEWS);
+
         news.setId(id);
+        news.setImageUrl(newsRepository.findOne(id).getImageUrl());
+
         Date published = newsRepository.findOne(id).getPublished();
         if (news.getType() == News.Type.RELEASED && published == null) {
             news.setPublished(new Date());

--- a/src/main/java/com/intive/patronage/toz/news/model/view/NewsView.java
+++ b/src/main/java/com/intive/patronage/toz/news/model/view/NewsView.java
@@ -37,7 +37,9 @@ public class NewsView extends IdentifiableView {
     @EnumValidate(enumClass = News.Type.class)
     private String type;
 
-    @ApiModelProperty(example = "storage/a9/2c/a92ccd6a-f51c-4ff0-8645-02adff409051.jpg", position = 4)
+    @ApiModelProperty(example = "storage/a9/2c/a92ccd6a-f51c-4ff0-8645-02adff409051.jpg",
+            readOnly = true, position = 4)
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String imageUrl;
 
     @ApiModelProperty(example = "1222333444555", position = 5)

--- a/src/main/java/com/intive/patronage/toz/pet/PetsService.java
+++ b/src/main/java/com/intive/patronage/toz/pet/PetsService.java
@@ -2,9 +2,9 @@ package com.intive.patronage.toz.pet;
 
 import com.intive.patronage.toz.error.exception.NotFoundException;
 import com.intive.patronage.toz.pet.model.db.Pet;
-import com.intive.patronage.toz.storage.model.db.UploadedFile;
 import com.intive.patronage.toz.status.PetsStatusRepository;
 import com.intive.patronage.toz.status.model.PetsStatus;
+import com.intive.patronage.toz.storage.model.db.UploadedFile;
 import com.intive.patronage.toz.util.RepositoryChecker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -73,8 +73,11 @@ class PetsService {
 
     Pet updatePet(final UUID id, final Pet pet) {
         RepositoryChecker.throwNotFoundExceptionIfNotExists(id, petsRepository, PET);
+
         pet.setId(id);
         pet.setGallery(petsRepository.findOne(id).getGallery());
+        pet.setImageUrl(petsRepository.findOne(id).getImageUrl());
+
         if (pet.getPetsStatus() != null) {
             PetsStatus petsStatus = petsStatusRepository.findOne(pet.getPetsStatus().getId());
             pet.setPetsStatus(petsStatus);
@@ -91,7 +94,7 @@ class PetsService {
         updatePet(id, pet);
     }
 
-    void throwNotFoundExceptionIfStatusNotExists(UUID id) {
+    private void throwNotFoundExceptionIfStatusNotExists(UUID id) {
         if (!petsStatusRepository.exists(id)) {
             throw new NotFoundException(PETS_STATUS);
         }

--- a/src/main/java/com/intive/patronage/toz/pet/model/view/PetView.java
+++ b/src/main/java/com/intive/patronage/toz/pet/model/view/PetView.java
@@ -24,49 +24,39 @@ import java.util.UUID;
 @SuppressWarnings("SpellCheckingInspection")
 public class PetView extends IdentifiableView {
 
+    @ApiModelProperty(position = 11)
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    protected List<UploadedFileView> gallery = new ArrayList<>();
     @ApiModelProperty(example = "Burek", position = 1)
     @Size(max = 35)
     private String name;
-
     @ApiModelProperty(example = "DOG", position = 2, allowableValues = "DOG,CAT", required = true)
     @NotNull
     @EnumValidate(enumClass = Pet.Type.class)
     private String type;
-
     @ApiModelProperty(example = "MALE", position = 3, allowableValues = "MALE,FEMALE")
     @EnumValidate(enumClass = Pet.Sex.class)
     private String sex;
-
     @ApiModelProperty(example = "Jamnik niskopodłogowy", position = 4)
     @Size(max = 1200)
     private String description;
-
     @ApiModelProperty(example = "Most cłowy", position = 5)
     @Size(max = 35)
     private String address;
-
     @ApiModelProperty(example = "c5296892-347f-4b2e-b1c6-6feaff971f67", position = 6)
     private UUID helperUuid;
-
     @ApiModelProperty(example = "1490134074968", position = 7)
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private Long created;
-
     @ApiModelProperty(example = "1490134074968", position = 8)
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private Long lastModified;
-
     @ApiModelProperty(example = "1490134074968", position = 9)
     private Long acceptanceDate;
-
-    @ApiModelProperty(example = "/storage/a5/0d/4d/a50d4d4c-ccd2-4747-8dec-d6d7f521336e.jpg", position = 10)
+    @ApiModelProperty(example = "/storage/a5/0d/4d/a50d4d4c-ccd2-4747-8dec-d6d7f521336e.jpg",
+            readOnly = true, position = 10)
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String imageUrl;
-
-    @ApiModelProperty(position = 11)
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    protected List<UploadedFileView> gallery = new ArrayList<>();
-
     @ApiModelProperty(example = "c5296892-347f-4b2e-b1c6-6faff971f767", position = 9)
     private UUID petsStatus;
 }


### PR DESCRIPTION
Do not change image on update (`PUT`), use existing one instead, so request body doesn't have to have `imageUrl` field.